### PR TITLE
fix test to be compatible with node 20+

### DIFF
--- a/src/kafka-registry-helper.spec.ts
+++ b/src/kafka-registry-helper.spec.ts
@@ -80,10 +80,11 @@ describe("KafkaRegistryHelper with AVRO", () => {
   })
 
   it("schema registry return an error other than 404", async () => {
-    nock(host).post(`/subjects/${subject}`).once().reply(403, "⚠️")
+    const message = "⚠️";
+    nock(host).post(`/subjects/${subject}`).once().reply(403, message)
 
     const result = registry.encodeForSubject(subject, message, SchemaType.AVRO, schema)
-    await expect(result).rejects.toThrowError(new SyntaxError("Unexpected token ⚠ in JSON at position 0"))
+    await expect(result).rejects.toThrowError(new SyntaxError(`Unexpected token '${message.charAt(0)}', "${message}" is not valid JSON`))
   })
 
   it("use schema from registry / schema not provided for encodeForSubject", async () => {

--- a/src/schema-registry-client.spec.ts
+++ b/src/schema-registry-client.spec.ts
@@ -228,11 +228,12 @@ describe("SchemaRegistryClient (Integration Tests)", () => {
 
     it("responds with invalid response body", async () => {
       const subject = "subject"
-      nock("http://test.com").post(`/subjects/${subject}`).reply(404, "not json")
+      const message = "not json";
+      nock("http://test.com").post(`/subjects/${subject}`).reply(404, message)
 
       const result = schemaApi.checkSchema(subject, { schema: fakeSchema.schema })
 
-      await expect(result).rejects.toThrowError(new SyntaxError("Unexpected token o in JSON at position 1"))
+      await expect(result).rejects.toThrowError(new SyntaxError(`Unexpected token '${message.charAt(1)}', "${message}" is not valid JSON`))
     })
   })
 


### PR DESCRIPTION
node 20 has changed the error to be more verbose and tries to point out which character causes the error. I tried to make this easy to change while updating the error message. I couldnt tell you why one needs charAt(0) and other needs charAt(1). I just know that the error message has changed